### PR TITLE
Match with app

### DIFF
--- a/match/route.go
+++ b/match/route.go
@@ -11,8 +11,9 @@ import (
 
 func Serve(w http.ResponseWriter, r *http.Request) {
 	var h http.Handler
-	var slug string
-	var id int
+	var apiWidget apiWidget
+	var apiWidgetPart apiWidgetPart
+	var widget widget
 
 	p := r.URL.Path
 	switch {
@@ -20,24 +21,26 @@ func Serve(w http.ResponseWriter, r *http.Request) {
 		h = get(home)
 	case match(p, "/contact"):
 		h = get(contact)
-	case match(p, "/api/widgets") && r.Method == "GET":
-		h = get(apiGetWidgets)
 	case match(p, "/api/widgets"):
-		h = post(apiCreateWidget)
-	case match(p, "/api/widgets/+", &slug):
-		h = post(apiWidget{slug}.update)
-	case match(p, "/api/widgets/+/parts", &slug):
-		h = post(apiWidget{slug}.createPart)
-	case match(p, "/api/widgets/+/parts/+/update", &slug, &id):
-		h = post(apiWidgetPart{slug, id}.update)
-	case match(p, "/api/widgets/+/parts/+/delete", &slug, &id):
-		h = post(apiWidgetPart{slug, id}.delete)
-	case match(p, "/+", &slug):
-		h = get(widget{slug}.widget)
-	case match(p, "/+/admin", &slug):
-		h = get(widget{slug}.admin)
-	case match(p, "/+/image", &slug):
-		h = post(widget{slug}.image)
+		if r.Method == "GET" {
+			h = get(apiGetWidgets)
+		} else {
+			h = post(apiCreateWidget)
+		}
+	case match(p, "/api/widgets/+", &apiWidget.slug):
+		h = post(apiWidget.update)
+	case match(p, "/api/widgets/+/parts", &apiWidget.slug):
+		h = post(apiWidget.createPart)
+	case match(p, "/api/widgets/+/parts/+/update", &apiWidgetPart.slug, &apiWidgetPart.id):
+		h = post(apiWidgetPart.update)
+	case match(p, "/api/widgets/+/parts/+/delete", &apiWidgetPart.slug, &apiWidgetPart.id):
+		h = post(apiWidgetPart.delete)
+	case match(p, "/+", &widget.slug):
+		h = get(widget.widget)
+	case match(p, "/+/admin", &widget.slug):
+		h = get(widget.admin)
+	case match(p, "/+/image", &widget.slug):
+		h = post(widget.image)
 	default:
 		http.NotFound(w, r)
 		return


### PR DESCRIPTION
```
$ go test -run ^$ -bench . -benchmem -count=3
goos: linux
goarch: amd64
pkg: github.com/benhoyt/go-routing
cpu: AMD Ryzen 7 PRO 4750GE with Radeon Graphics
BenchmarkRouters/chi-16                   431440              2556 ns/op            1017 B/op         11 allocs/op
BenchmarkRouters/chi-16                   492919              2614 ns/op            1017 B/op         11 allocs/op
BenchmarkRouters/chi-16                   490640              2815 ns/op            1017 B/op         11 allocs/op
BenchmarkRouters/gorilla-16               260954              5067 ns/op            1890 B/op         17 allocs/op
BenchmarkRouters/gorilla-16               211863              5152 ns/op            1890 B/op         17 allocs/op
BenchmarkRouters/gorilla-16               211245              5168 ns/op            1890 B/op         17 allocs/op
BenchmarkRouters/match-16                 632740              2068 ns/op             672 B/op         12 allocs/op
BenchmarkRouters/match-16                1000000              1900 ns/op             672 B/op         12 allocs/op
BenchmarkRouters/match-16                1000000              1904 ns/op             672 B/op         12 allocs/op
BenchmarkRouters/pat-16                   175828              7020 ns/op            2993 B/op         46 allocs/op
BenchmarkRouters/pat-16                   183079              6919 ns/op            2993 B/op         46 allocs/op
BenchmarkRouters/pat-16                   161582              7049 ns/op            2993 B/op         46 allocs/op
BenchmarkRouters/reswitch-16              412538              2912 ns/op             736 B/op         11 allocs/op
BenchmarkRouters/reswitch-16              470283              2915 ns/op             736 B/op         11 allocs/op
BenchmarkRouters/reswitch-16              429408              2919 ns/op             736 B/op         11 allocs/op
BenchmarkRouters/retable-16               310527              3459 ns/op            1145 B/op         13 allocs/op
BenchmarkRouters/retable-16               361617              3640 ns/op            1145 B/op         13 allocs/op
BenchmarkRouters/retable-16               328449              3397 ns/op            1145 B/op         13 allocs/op
BenchmarkRouters/shiftpath-16             457556              2944 ns/op             952 B/op         26 allocs/op
BenchmarkRouters/shiftpath-16             434763              3057 ns/op             952 B/op         26 allocs/op
BenchmarkRouters/shiftpath-16             406228              2900 ns/op             952 B/op         26 allocs/op
BenchmarkRouters/split-16                 836352              1798 ns/op             736 B/op         10 allocs/op
BenchmarkRouters/split-16                 621984              1837 ns/op             736 B/op         10 allocs/op
BenchmarkRouters/split-16                 598485              1906 ns/op             736 B/op         10 allocs/op
BenchmarkRouters/noop-16                 1000000              1104 ns/op             544 B/op          6 allocs/op
BenchmarkRouters/noop-16                  894861              1201 ns/op             544 B/op          6 allocs/op
BenchmarkRouters/noop-16                 1000000              1142 ns/op             544 B/op          6 allocs/op
PASS
ok      github.com/benhoyt/go-routing   39.987s
```