### PR TITLE
Tweak match

### DIFF
--- a/match/route.go
+++ b/match/route.go
@@ -11,8 +11,9 @@ import (
 
 func Serve(w http.ResponseWriter, r *http.Request) {
 	var h http.Handler
-	var slug string
-	var id int
+	var apiWidget apiWidget
+	var apiWidgetPart apiWidgetPart
+	var widget widget
 
 	p := r.URL.Path
 	switch {
@@ -20,24 +21,26 @@ func Serve(w http.ResponseWriter, r *http.Request) {
 		h = get(home)
 	case match(p, "/contact"):
 		h = get(contact)
-	case match(p, "/api/widgets") && r.Method == "GET":
-		h = get(apiGetWidgets)
 	case match(p, "/api/widgets"):
-		h = post(apiCreateWidget)
-	case match(p, "/api/widgets/+", &slug):
-		h = post(apiWidget{slug}.update)
-	case match(p, "/api/widgets/+/parts", &slug):
-		h = post(apiWidget{slug}.createPart)
-	case match(p, "/api/widgets/+/parts/+/update", &slug, &id):
-		h = post(apiWidgetPart{slug, id}.update)
-	case match(p, "/api/widgets/+/parts/+/delete", &slug, &id):
-		h = post(apiWidgetPart{slug, id}.delete)
-	case match(p, "/+", &slug):
-		h = get(widget{slug}.widget)
-	case match(p, "/+/admin", &slug):
-		h = get(widget{slug}.admin)
-	case match(p, "/+/image", &slug):
-		h = post(widget{slug}.image)
+		if r.Method == "GET" {
+			h = get(apiGetWidgets)
+		} else {
+			h = post(apiCreateWidget)
+		}
+	case match(p, "/api/widgets/+", &apiWidget.slug):
+		h = post(apiWidget.update)
+	case match(p, "/api/widgets/+/parts", &apiWidget.slug):
+		h = post(apiWidget.createPart)
+	case match(p, "/api/widgets/+/parts/+/update", &apiWidgetPart.slug, &apiWidgetPart.id):
+		h = post(apiWidgetPart.update)
+	case match(p, "/api/widgets/+/parts/+/delete", &apiWidgetPart.slug, &apiWidgetPart.id):
+		h = post(apiWidgetPart.delete)
+	case match(p, "/+", &widget.slug):
+		h = get(widget.widget)
+	case match(p, "/+/admin", &widget.slug):
+		h = get(widget.admin)
+	case match(p, "/+/image", &widget.slug):
+		h = post(widget.image)
 	default:
 		http.NotFound(w, r)
 		return


### PR DESCRIPTION
```
$ go test -run ^$ -bench . -benchmem -count=3
goos: linux
goarch: amd64
pkg: github.com/benhoyt/go-routing
cpu: AMD Ryzen 7 PRO 4750GE with Radeon Graphics
BenchmarkRouters/chi-16                   431264              2706 ns/op            1017 B/op         11 allocs/op
BenchmarkRouters/chi-16                   476079              2689 ns/op            1017 B/op         11 allocs/op
BenchmarkRouters/chi-16                   566511              2801 ns/op            1017 B/op         11 allocs/op
BenchmarkRouters/gorilla-16               254318              5174 ns/op            1890 B/op         17 allocs/op
BenchmarkRouters/gorilla-16               205888              5186 ns/op            1890 B/op         17 allocs/op
BenchmarkRouters/gorilla-16               313141              5069 ns/op            1890 B/op         17 allocs/op
BenchmarkRouters/match-16                 549056              2479 ns/op            1096 B/op         13 allocs/op
BenchmarkRouters/match-16                 529450              2511 ns/op            1096 B/op         13 allocs/op
BenchmarkRouters/match-16                 408393              2596 ns/op            1096 B/op         13 allocs/op
BenchmarkRouters/pat-16                   187000              7500 ns/op            2993 B/op         46 allocs/op
BenchmarkRouters/pat-16                   219438              7533 ns/op            2993 B/op         46 allocs/op
BenchmarkRouters/pat-16                   142377              7039 ns/op            2993 B/op         46 allocs/op
BenchmarkRouters/reswitch-16              314497              3342 ns/op             736 B/op         11 allocs/op
BenchmarkRouters/reswitch-16              463942              3190 ns/op             736 B/op         11 allocs/op
BenchmarkRouters/reswitch-16              425689              3107 ns/op             736 B/op         11 allocs/op
BenchmarkRouters/retable-16               365866              4046 ns/op            1145 B/op         13 allocs/op
BenchmarkRouters/retable-16               356115              3750 ns/op            1145 B/op         13 allocs/op
BenchmarkRouters/retable-16               284763              3557 ns/op            1145 B/op         13 allocs/op
BenchmarkRouters/shiftpath-16             413098              3172 ns/op             952 B/op         26 allocs/op
BenchmarkRouters/shiftpath-16             403398              3223 ns/op             952 B/op         26 allocs/op
BenchmarkRouters/shiftpath-16             350100              3009 ns/op             952 B/op         26 allocs/op
BenchmarkRouters/split-16                 503872              2107 ns/op             736 B/op         10 allocs/op
BenchmarkRouters/split-16                 563388              1921 ns/op             736 B/op         10 allocs/op
BenchmarkRouters/split-16                 540402              2088 ns/op             736 B/op         10 allocs/op
BenchmarkRouters/noop-16                  968200              1205 ns/op             544 B/op          6 allocs/op
BenchmarkRouters/noop-16                  961322              1156 ns/op             544 B/op          6 allocs/op
BenchmarkRouters/noop-16                 1000000              1239 ns/op             544 B/op          6 allocs/op
PASS
ok      github.com/benhoyt/go-routing   37.799s
```